### PR TITLE
Fix UnboundLocalError on first run when no card catalog exists

### DIFF
--- a/APIScraping/UpdateHandler.py
+++ b/APIScraping/UpdateHandler.py
@@ -14,6 +14,8 @@ def checkForNewCardData(newCardCatalog: Dict = None, fieldsToIgnore: List[str] =
 	oldCards: Dict[int, Dict] = {}
 	# Keep track of known card fields, so we can notice if new cards add new fields
 	knownCardFieldNames: List[str] = []
+	# Initialize oldCardCatalog with empty structure that will be used if no stored catalog exists
+	oldCardCatalog: Dict = {"cards": {}, "card_sets": [], "application_shared_properties": {"current_app_version": ""}}
 	pathToCardCatalog = os.path.join("downloads", "json", f"carddata.{GlobalConfig.language.code}.json")
 	if os.path.isfile(pathToCardCatalog):
 		with open(pathToCardCatalog, "r") as cardCatalogFile:


### PR DESCRIPTION
Initialize oldCardCatalog with empty structure before the if/else block to ensure the variable exists in all code paths. Previously, the variable was only defined inside the if block when a local file existed, causing UnboundLocalError at lines 133-141 when accessed during first-run scenarios.